### PR TITLE
Bridge and prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The role uses the same variable names as `Network Scripts`. It is recommended to
 > `prefix`: the subnet mask use with the `ipaddr`
 >
 > `group`: the multicast group the VXLAN will operate on
+>
+> `bridge`: if set establish a bridge between this VXLAN and the specified interface
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ You may also define multiple VXLAN interfaces per host however you must provide 
         vni: 20
         group: 224.0.0.200
 
+You may also set a bridge for vxlan interface to operate over.
+
+  ### /host_vars/host1
+
+    vxlan_interfaces:
+      - device: vxlan0
+        group: 224.0.0.10
+        bridge: breth1
+
 License
 -------
 

--- a/templates/ifcfg-vxlan.j2
+++ b/templates/ifcfg-vxlan.j2
@@ -5,7 +5,7 @@ GROUP={{ item.group }}
 TTL={{ item.ttl | default(vxlan_ttl) }}
 PHYS_DEV={{ item.phys_dev | default(vxlan_phys_dev) }}
 DSTPORT={{ item.dstport | default(vxlan_dstport) }}
-{% if item.ipaddr is defined %}
+{% if item.ipaddr is defined and item.prefix is defined %}
 IPADDR={{ item.ipaddr }}
 PREFIX={{ item.prefix }}
 {% endif %}

--- a/templates/ifcfg-vxlan.j2
+++ b/templates/ifcfg-vxlan.j2
@@ -11,3 +11,6 @@ PREFIX={{ item.prefix }}
 {% endif %}
 BOOTPROTO={{ item.bootproto | default(vxlan_bootproto) }}
 ONBOOT={{ item.onboot | default(vxlan_onboot) }}
+{% if item.bridge is defined %}
+BRIDGE={{ item.bridge }}
+{% endif %}


### PR DESCRIPTION
Add support for setting a `bridge` for the VXLAN interface and also ensure `prefix` is defined before adding `ipaddr`