### PR TITLE
Add support for Ubuntu distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 VXLAN
 =========
 
-This role creates persistent VXLAN interfaces with the use of [Network Scripts](https://pkgs.org/download/network-scripts) or [NetworkManger](https://pkgs.org/download/NetworkManager).
+This role creates persistent VXLAN interfaces with the use of [Network Scripts](https://pkgs.org/download/network-scripts), [NetworkManger](https://pkgs.org/download/NetworkManager), or [Systemd-Networkd](https://www.freedesktop.org/software/systemd/man/systemd-networkd.service.html).
 
 Role Variables
 --------------
@@ -16,22 +16,22 @@ The role uses the same variable names as `Network Scripts`. It is recommended to
 
 `vxlan_dstport`: set the port for the VXLAN to reside on
 
-`vxlan_bootproto`: specify boot protocol used with the interface (unsupported when using NetworkManger, always none)
+`vxlan_bootproto`: specify boot protocol used with the interface (unsupported when using NetworkManger or Systemd-Networkd, always none)
 
-`vxlan_onboot`: set to `yes` if the VXLAN interface should be brought up on boot otherwise `no`
+`vxlan_onboot`: set to `yes` if the VXLAN interface should be brought up on boot otherwise `no` (Not supported on Systemd-networkd)
 
 `vxlan_interfaces`: list of interfaces to be created can set specific instances of the variables defined above in addition to some others
 > `device`: name assigned the VXLAN interface
 >
-> `ipaddr`: the IPV4 address assigned to the VXLAN interface (unsupported when using NetworkManger)
+> `ipaddr`: the IPV4 address assigned to the VXLAN interface (unsupported when using NetworkManger or Systemd-Networkd)
 >
-> `prefix`: the subnet mask use with the `ipaddr` (unsupported when using NetworkManger)
+> `prefix`: the subnet mask use with the `ipaddr` (unsupported when using NetworkManger or Systemd-Networkd)
 >
 > `group`: the multicast group the VXLAN will operate on
 >
 > `bridge`: if set establish a bridge between this VXLAN and the specified interface
 
-By default, Network Scripts will be used unless it is unavailable. Usage of either Network Scripts or NetworkManager enforced by setting `force_ns` or `force_nm` to true. 
+By default, Network Scripts will be used unless it is unavailable. Usage of either Network Scripts, NetworkManager or Systemd-Networkd can be enforced by setting `force_ns`, `force_nm`, or `force_sd` to true. 
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,4 @@ vxlan_interfaces: []
 
 force_nm: false
 force_ns: false
+force_sd: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,4 +18,7 @@
   when: (not install_result.failed) or force_ns
 
 - include_tasks: networkmanager.yml
-  when: (install_result.failed) or force_nm
+  when: (install_result.failed and ansible_facts['distribution'] == "Rocky") or force_nm
+
+- include_tasks: systemd-networkd.yml
+  when: (install_result.failed and ansible_facts['distribution'] == "Ubuntu") or force_sd

--- a/tasks/systemd-networkd.yml
+++ b/tasks/systemd-networkd.yml
@@ -1,0 +1,28 @@
+---
+- name: Ensure systemd-networkd vxlan .netdev files exist
+  ansible.builtin.template:
+    src: "templates/systemd-networkd-vxlan.netdev.j2"
+    dest: /etc/systemd/network/{{ item.device }}.netdev
+  with_items: "{{ vxlan_interfaces }}"
+  become: true
+
+- name: Ensure systemd-networkd drop-in directory exists
+  ansible.builtin.file:
+    path: /etc/systemd/network/50-kayobe-{{ item.phys_dev | default(vxlan_phys_dev) }}.network.d
+    state: directory
+    mode: "0755"
+  with_items: "{{ vxlan_interfaces }}"
+  become: true
+
+- name: Ensure systemd-networkd drop-in config file exists
+  ansible.builtin.template:
+    src: "templates/systemd-networkd-vxlan-drop-in.conf.j2"
+    dest: /etc/systemd/network/50-kayobe-{{ item.phys_dev | default(vxlan_phys_dev) }}.network.d/10-{{ item.device }}.conf
+  with_items: "{{ vxlan_interfaces }}"
+  become: true
+
+- name: Restart systemd-networkd
+  systemd:
+    state: restarted
+    name: systemd-networkd
+  become: true

--- a/templates/systemd-networkd-vxlan-drop-in.conf.j2
+++ b/templates/systemd-networkd-vxlan-drop-in.conf.j2
@@ -1,0 +1,2 @@
+[Network]
+VXLAN={{ item.device }}

--- a/templates/systemd-networkd-vxlan.netdev.j2
+++ b/templates/systemd-networkd-vxlan.netdev.j2
@@ -1,0 +1,9 @@
+[NetDev]
+Name={{ item.device }}
+Kind=vxlan
+
+[VXLAN]
+VNI={{ item.vni | default(vxlan_vni) }}
+Group={{ item.group }}
+TTL={{ item.ttl | default(vxlan_ttl) }}
+DestinationPort={{ item.dstport | default(vxlan_dstport) }}


### PR DESCRIPTION
Adds vxlan support for Ubuntu distributions by making use of systemd-networkd. Adds the needed config for the vxlan netdev and adds drop-in config for the vxlan parent interface.